### PR TITLE
Fix for rerender bug

### DIFF
--- a/lib/Popover.js
+++ b/lib/Popover.js
@@ -40,10 +40,12 @@ class Popover extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.isVisible !== this.props.isVisible && !this.props.isVisible) {
-      this.unregisterSelf();
-    } else {
-      this.registerSelf();
+    if (prevProps.isVisible !== this.props.isVisible) {
+      if (this.props.isVisible) {
+        this.registerSelf();
+      } else {
+        this.unregisterSelf();
+      }
     }
   }
 


### PR DESCRIPTION
Thanks for the amazing library. I found one bug. When te children of the popover changes the component did update and since the previous props of the visible have not changed the component will register itself again.