### PR TITLE
Added custom props and fix arrow issue on Android with RN 0.51

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Renders component with defined properties around the wrapped component.
 | arrowHeight   | Number         | `10`       | Popover's arrow height.                                     |
 | placement     | String         | `'auto'`   | Where popover should be placed related to the wrapped component. If `'auto'`, all placement options are tried and first suitable placement option is picked. Supported placement options: `'left'`, `'right'`, `'top'`, `'bottom'`, `'auto'`.                                                         |
 | children      | ReactElement   | `null`       | Element that you want your popover to point to.           |
+| pointerEvents | String         | `null`       | Controls whether the View can be the target of touch event. Supported options: `'auto'`, `'none'`, `'box-none'` and `'box-only'`.                          |
+| offset        | Object         | `{ x: 0, y: 0 }` | Popover's offset setting.                             |
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Renders component with defined properties around the wrapped component.
 | arrowHeight   | Number         | `10`       | Popover's arrow height.                                     |
 | placement     | String         | `'auto'`   | Where popover should be placed related to the wrapped component. If `'auto'`, all placement options are tried and first suitable placement option is picked. Supported placement options: `'left'`, `'right'`, `'top'`, `'bottom'`, `'auto'`.                                                         |
 | children      | ReactElement   | `null`       | Element that you want your popover to point to.           |
-| pointerEvents | String         | `null`       | Controls whether the View can be the target of touch event. Supported options: `'auto'`, `'none'`, `'box-none'` and `'box-only'`.                          |
+| pointerEvents | String         | `'box-none'` | Controls whether the View can be the target of touch event. Supported options: `'auto'`, `'none'`, `'box-none'` and `'box-only'`.                          |
 | offset        | Object         | `{ x: 0, y: 0 }` | Popover's offset setting.                             |
 
 ## Example

--- a/lib/Popover.js
+++ b/lib/Popover.js
@@ -16,6 +16,7 @@ class Popover extends PureComponent {
     arrowWidth: PropTypes.number,
     arrowHeight: PropTypes.number,
     placement: PropTypes.oneOf(['left', 'right', 'top', 'bottom', 'auto']),
+    pointerEvents: PropTypes.string,
   };
 
   static defaultProps = {
@@ -25,6 +26,7 @@ class Popover extends PureComponent {
     arrowWidth: 15,
     arrowHeight: 10,
     placement: 'auto',
+    pointerEvents: null,
   };
 
   constructor(props) {
@@ -66,14 +68,16 @@ class Popover extends PureComponent {
           arrowWidth,
           arrowHeight,
           placement,
-          component
+          component,
+          pointerEvents,
         } = this.props;
         this.context.registerPopover(this._id, findNodeHandle(this._element), {
           arrowColor,
           arrowWidth,
           arrowHeight,
           placement,
-          component
+          component,
+          pointerEvents,
         });
       }
     });

--- a/lib/Popover.js
+++ b/lib/Popover.js
@@ -50,7 +50,7 @@ class Popover extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.isVisible !== this.props.isVisible) {
+    if (prevProps.isVisible !== this.props.isVisible || prevProps.placement !== this.props.placement) {
       if (this.props.isVisible) {
         this.registerSelf();
       } else {

--- a/lib/Popover.js
+++ b/lib/Popover.js
@@ -30,7 +30,7 @@ class Popover extends PureComponent {
     arrowWidth: 15,
     arrowHeight: 10,
     placement: 'auto',
-    pointerEvents: null,
+    pointerEvents: 'box-none',
     offset: {
       x: 0,
       y: 0,

--- a/lib/Popover.js
+++ b/lib/Popover.js
@@ -17,6 +17,10 @@ class Popover extends PureComponent {
     arrowHeight: PropTypes.number,
     placement: PropTypes.oneOf(['left', 'right', 'top', 'bottom', 'auto']),
     pointerEvents: PropTypes.string,
+    offset: PropTypes.shape({
+      x: PropTypes.number.isRequired,
+      y: PropTypes.number.isRequired,
+    }),
   };
 
   static defaultProps = {
@@ -27,6 +31,10 @@ class Popover extends PureComponent {
     arrowHeight: 10,
     placement: 'auto',
     pointerEvents: null,
+    offset: {
+      x: 0,
+      y: 0,
+    },
   };
 
   constructor(props) {
@@ -70,6 +78,7 @@ class Popover extends PureComponent {
           placement,
           component,
           pointerEvents,
+          offset,
         } = this.props;
         this.context.registerPopover(this._id, findNodeHandle(this._element), {
           arrowColor,
@@ -78,6 +87,7 @@ class Popover extends PureComponent {
           placement,
           component,
           pointerEvents,
+          offset,
         });
       }
     });

--- a/lib/PopoverElement.js
+++ b/lib/PopoverElement.js
@@ -23,10 +23,18 @@ class PopoverElement extends Component {
       ['left', 'right', 'top', 'bottom', 'auto']
     ).isRequired,
     pointerEvents: PropTypes.string,
+    offset: PropTypes.shape({
+      x: PropTypes.number.isRequired,
+      y: PropTypes.number.isRequired,
+    }),
   };
 
   static defaultProps = {
     pointerEvents: null,
+    offset: {
+      x: 0,
+      y: 0,
+    },
   };
 
   constructor(props) {
@@ -53,6 +61,7 @@ class PopoverElement extends Component {
     padding,
     placement,
   }) {
+    const { offset } = this.props;
     const { width, height } = this.state;
     const geom = computeGeometry({
       contentSize: { width, height },
@@ -68,8 +77,8 @@ class PopoverElement extends Component {
     this.setState({
       containerStyle: {
         ...this.state.containerStyle,
-        top: geom.popoverOrigin.y,
-        left: geom.popoverOrigin.x,
+        top: geom.popoverOrigin.y + offset.y,
+        left: geom.popoverOrigin.x + offset.x,
       },
       arrowStyle: geom.arrowStyle,
     });

--- a/lib/PopoverElement.js
+++ b/lib/PopoverElement.js
@@ -22,6 +22,11 @@ class PopoverElement extends Component {
     placement: PropTypes.oneOf(
       ['left', 'right', 'top', 'bottom', 'auto']
     ).isRequired,
+    pointerEvents: PropTypes.string,
+  };
+
+  static defaultProps = {
+    pointerEvents: null,
   };
 
   constructor(props) {
@@ -80,17 +85,23 @@ class PopoverElement extends Component {
   };
 
   render() {
+    const { pointerEvents, component, arrowColor } = this.props;
+
     return (
-      <View style={[styles.abs, this.state.containerStyle]}>
-        <View onLayout={this.measureLayout}>
-          {React.createElement(this.props.component)}
+      <View
+        style={[styles.abs, this.state.containerStyle]}
+        pointerEvents={pointerEvents}
+      >
+        <View onLayout={this.measureLayout} pointerEvents={pointerEvents}>
+          {React.createElement(component)}
         </View>
         <View
           style={[
             styles.abs,
             this.state.arrowStyle,
-            { borderColor: this.props.arrowColor },
+            { borderColor: arrowColor },
           ]}
+          pointerEvents={pointerEvents}
         />
       </View>
     );

--- a/lib/PopoverElement.js
+++ b/lib/PopoverElement.js
@@ -2,6 +2,11 @@ import React, { Component } from 'react';
 import { StyleSheet, View, ViewPropTypes } from 'react-native';
 import PropTypes from 'prop-types';
 import computeGeometry from './computeGeometry';
+import {
+  PLACEMENT_OPTIONS,
+  capitalizeFirstLetter,
+  findDirectionWithoutColor,
+} from './utils';
 
 class PopoverElement extends Component {
   static propTypes = {
@@ -71,8 +76,8 @@ class PopoverElement extends Component {
         width: arrowWidth,
         height: arrowHeight,
       },
-      padding: padding,
-      placement: placement,
+      padding,
+      placement,
     });
     this.setState({
       containerStyle: {
@@ -94,7 +99,8 @@ class PopoverElement extends Component {
   };
 
   render() {
-    const { pointerEvents, component, arrowColor } = this.props;
+    const { pointerEvents, component, placement, arrowColor } = this.props;
+    const borderDirection = capitalizeFirstLetter(findDirectionWithoutColor(this.state.arrowStyle));
 
     return (
       <View
@@ -107,7 +113,7 @@ class PopoverElement extends Component {
           style={[
             styles.abs,
             this.state.arrowStyle,
-            { borderColor: arrowColor },
+            { [`border${borderDirection}Color`]: arrowColor },
           ]}
           pointerEvents={pointerEvents}
         />

--- a/lib/PopoverElement.js
+++ b/lib/PopoverElement.js
@@ -30,7 +30,7 @@ class PopoverElement extends Component {
   };
 
   static defaultProps = {
-    pointerEvents: null,
+    pointerEvents: 'box-none',
     offset: {
       x: 0,
       y: 0,
@@ -99,9 +99,8 @@ class PopoverElement extends Component {
     return (
       <View
         style={[styles.abs, this.state.containerStyle]}
-        pointerEvents={pointerEvents}
       >
-        <View onLayout={this.measureLayout} pointerEvents={pointerEvents}>
+        <View onLayout={this.measureLayout}>
           {React.createElement(component)}
         </View>
         <View

--- a/lib/computeGeometry.js
+++ b/lib/computeGeometry.js
@@ -1,10 +1,4 @@
-const PLACEMENT_OPTIONS = {
-  TOP: 'top',
-  RIGHT: 'right',
-  BOTTOM: 'bottom',
-  LEFT: 'left',
-  AUTO: 'auto',
-};
+import { PLACEMENT_OPTIONS, getArrowStyle } from './utils';
 
 function Point(x, y) {
   this.x = x;
@@ -45,46 +39,6 @@ const computeGeometry = ({
     default:
       return computeAutoGeometry(options);
   }
-};
-
-const getArrowStyle = ({
-  anchorPoint,
-  popoverOrigin,
-  arrowSize,
-  placement,
-}) => {
-  let width;
-  let height;
-  // swap width and height for left/right positioned tooltips
-  if (
-    placement === PLACEMENT_OPTIONS.TOP ||
-    placement === PLACEMENT_OPTIONS.BOTTOM
-  ) {
-    width = arrowSize.width;
-    height = arrowSize.height * 2;
-  } else {
-    width = arrowSize.height * 2;
-    height = arrowSize.width;
-  }
-
-  return {
-    width,
-    height,
-    left: anchorPoint.x - popoverOrigin.x - width / 2,
-    top: anchorPoint.y - popoverOrigin.y - height / 2,
-    borderTopWidth: height / 2,
-    borderRightWidth: width / 2,
-    borderBottomWidth: height / 2,
-    borderLeftWidth: width / 2,
-    borderTopColor:
-      placement === PLACEMENT_OPTIONS.TOP ? undefined : 'transparent',
-    borderRightColor:
-      placement === PLACEMENT_OPTIONS.RIGHT ? undefined : 'transparent',
-    borderBottomColor:
-      placement === PLACEMENT_OPTIONS.BOTTOM ? undefined : 'transparent',
-    borderLeftColor:
-      placement === PLACEMENT_OPTIONS.LEFT ? undefined : 'transparent',
-  };
 };
 
 const computeTopGeometry = ({

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,57 @@
+const PLACEMENT_OPTIONS = {
+  TOP: 'top',
+  RIGHT: 'right',
+  BOTTOM: 'bottom',
+  LEFT: 'left',
+  AUTO: 'auto',
+};
+
+const capitalizeFirstLetter = (string) => {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+};
+
+const getArrowStyle = ({
+  anchorPoint,
+  popoverOrigin,
+  arrowSize,
+  placement,
+}) => {
+  let width;
+  let height;
+  // swap width and height for left/right positioned tooltips
+  if (
+    placement === PLACEMENT_OPTIONS.TOP ||
+    placement === PLACEMENT_OPTIONS.BOTTOM
+  ) {
+    width = arrowSize.width;
+    height = arrowSize.height * 2;
+  } else {
+    width = arrowSize.height * 2;
+    height = arrowSize.width;
+  }
+
+  return {
+    width,
+    height,
+    left: anchorPoint.x - popoverOrigin.x - width / 2,
+    top: anchorPoint.y - popoverOrigin.y - height / 2,
+    borderTopWidth: height / 2,
+    borderRightWidth: width / 2,
+    borderBottomWidth: height / 2,
+    borderLeftWidth: width / 2,
+    borderTopColor:
+      placement === PLACEMENT_OPTIONS.TOP ? undefined : 'transparent',
+    borderRightColor:
+      placement === PLACEMENT_OPTIONS.RIGHT ? undefined : 'transparent',
+    borderBottomColor:
+      placement === PLACEMENT_OPTIONS.BOTTOM ? undefined : 'transparent',
+    borderLeftColor:
+      placement === PLACEMENT_OPTIONS.LEFT ? undefined : 'transparent',
+  };
+};
+
+export {
+  PLACEMENT_OPTIONS,
+  capitalizeFirstLetter,
+  getArrowStyle,
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,7 +7,24 @@ const PLACEMENT_OPTIONS = {
 };
 
 const capitalizeFirstLetter = (string) => {
+  if (!string) {
+    return '';
+  }
+
   return string.charAt(0).toUpperCase() + string.slice(1);
+};
+
+const findDirectionWithoutColor = (arrowStyle) => {
+  const placements = ['top', 'right', 'bottom', 'left'];
+  const directionsWithColor = Object.keys(arrowStyle || {}).filter((key) => {
+    return /border[a-z]*Color/i.test(key);
+  }).filter((key) => {
+    return arrowStyle[key] === undefined;
+  }).map((key) => {
+    return key.replace(/border/i, '').replace(/color/i, '').toLowerCase();
+  });
+
+  return directionsWithColor[0];
 };
 
 const getArrowStyle = ({
@@ -53,5 +70,6 @@ const getArrowStyle = ({
 export {
   PLACEMENT_OPTIONS,
   capitalizeFirstLetter,
+  findDirectionWithoutColor,
   getArrowStyle,
 };


### PR DESCRIPTION
Hey, thank you for this awesome component!
This PR made following changes:

* Added custom props:
    * `pointerEvents`:
       Sometimes the arrow element might block the press behavior of element behind it. We could set the `pointerEvents: 'box-none'` to make the press behavior could pass to the element behind it.

    * `offset`:
       By changing the `offset` value, we could modify the distance between the element and the arrow.

* Moved helper functions to `utils.js`
* Fixed the updating behavior of placement
* Fixed the broken arrow issue on Android with RN 0.51
   Seems RN 0.51 changed the border style implementation, so we should fix the style syntax.
   
    Before:
    <img width="957" alt="2017-12-21 12 56 46" src="https://user-images.githubusercontent.com/3055294/34241308-948bd75c-e64f-11e7-840f-fe085179e688.png">


    After:
    <img width="956" alt="2017-12-21 12 57 00" src="https://user-images.githubusercontent.com/3055294/34241309-98f56a56-e64f-11e7-9fce-423f1e9a7f0b.png">


Please take a look when you have time, and let me know if you have any suggestions. 😄 
Many thanks!